### PR TITLE
Add: BootStrapCDN #28

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,5 +8,8 @@ html
     = csp_meta_tag
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_importmap_tags
+    link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous"
+    script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"
   body
-    = yield
+    .container
+      = yield


### PR DESCRIPTION
## 概要
Closes #28 
とりあえずBootStrapで進めていきましょう！CDNで！
5系なのでこちらを参考に！
https://getbootstrap.jp/docs/5.0/components/navbar/

ここでHTMLをslimに変換しましょう！
https://html2slim.herokuapp.com

ついでに`.container`で囲っておきました。

## 確認方法

## 影響範囲

## チェックリスト

- [ ] rubocopをパスした
- [ ] rspecをパスした

## コメント

