### PR TITLE
スキーマがコンフリクトしてたので、マイグレーション削除

### DIFF
--- a/db/migrate/20220906022645_change_column_null_areas.rb
+++ b/db/migrate/20220906022645_change_column_null_areas.rb
@@ -1,7 +1,0 @@
-class ChangeColumnNullAreas < ActiveRecord::Migration[7.0]
-  def change
-    change_column_null :areas, :opened_at, false
-    change_column_null :areas, :closed_at, false
-    change_column_null :areas, :address, false
-  end
-end

--- a/db/migrate/20220906024038_add_note_to_areas.rb
+++ b/db/migrate/20220906024038_add_note_to_areas.rb
@@ -1,5 +1,0 @@
-class AddNoteToAreas < ActiveRecord::Migration[7.0]
-  def change
-    add_column :areas, :note, :string
-  end
-end

--- a/db/migrate/20220906025026_add_message_to_places.rb
+++ b/db/migrate/20220906025026_add_message_to_places.rb
@@ -1,6 +1,0 @@
-class AddMessageToPlaces < ActiveRecord::Migration[7.0]
-  def change
-    add_column :places, :message, :text
-    add_column :places, :city, :string
-  end
-end


### PR DESCRIPTION
## 概要

スキーマファイルがコンフリクトしてたので、後から追加されたマイグレーションファイルを削除しました

## 確認方法

1. migrate:resetしてください

## 影響範囲

* マイグレーション
