### PR TITLE
Feature/issue 58

### DIFF
--- a/app/javascript/custom/calendar.js
+++ b/app/javascript/custom/calendar.js
@@ -4,5 +4,6 @@ const config = {
     altInput: true,
     altFormat: "m/d    H:i",  // 実際に画面に表示されるフォーマット
     dateFormat: "Y-m-d H:i",  // valueの中身のフォーマット
+    locale: 'ja'
 }
 flatpickr('#calendar', config);

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,7 +13,9 @@ html
     / TODO: FontAwesomeの無料枠だと数少ないから代替案必要
     link rel ="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css"
     link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet"
+    link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/themes/material_green.css" rel="stylesheet"
     script src="https://cdn.jsdelivr.net/npm/flatpickr"
+    script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/ja.js"
   body style="background-color: #fffff0;"
     = render 'shared/header'
     .container

--- a/db/migrate/20220906022645_change_column_null_areas.rb
+++ b/db/migrate/20220906022645_change_column_null_areas.rb
@@ -1,7 +1,0 @@
-class ChangeColumnNullAreas < ActiveRecord::Migration[7.0]
-  def change
-    change_column_null :areas, :opened_at, false
-    change_column_null :areas, :closed_at, false
-    change_column_null :areas, :address, false
-  end
-end

--- a/db/migrate/20220906024038_add_note_to_areas.rb
+++ b/db/migrate/20220906024038_add_note_to_areas.rb
@@ -1,5 +1,0 @@
-class AddNoteToAreas < ActiveRecord::Migration[7.0]
-  def change
-    add_column :areas, :note, :string
-  end
-end

--- a/db/migrate/20220906025026_add_message_to_places.rb
+++ b/db/migrate/20220906025026_add_message_to_places.rb
@@ -1,6 +1,0 @@
-class AddMessageToPlaces < ActiveRecord::Migration[7.0]
-  def change
-    add_column :places, :message, :text
-    add_column :places, :city, :string
-  end
-end


### PR DESCRIPTION
## 概要

* close #58 
* カレンダーの日本語表示とヘッダを緑に

## 確認方法

* トップページ、ヘッダの開始日時にフォーカスを当てたら日本語のカレンダーが表示される

## コメント

* マイグレーション通らなかったので #57 も取り込んでます。
