### PR TITLE
cycleを考慮して1ヶ月先までのスケジュールを自動で作成する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'sorcery'
 gem 'ransack'
 gem 'rails-i18n'
 gem 'kaminari'
+gem 'whenever', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -349,6 +350,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.0)
@@ -394,6 +397,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  whenever
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -15,6 +15,6 @@ class PlacesController < ApplicationController
 
   def set_schedules
     @q = Schedule.ransack(params[:q])
-    @schedules = @q.result.page(params[:page]).includes(area_sport: [:sport, { area: :place }])
+    @schedules = @q.result.page(params[:page]).includes(area_sport: [:sport, { area: :place }]).order(started_at: :asc, finished_at: :asc).order("sport.name")
   end
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -21,7 +21,7 @@
 class Batch < ApplicationRecord
   enum cycle: {
     unknown: 0,
-    every: 1,
+    every: 1, # 施設の開館時間は常にできるスポーツ
     every_monday: 10,
     first_monday: 11,
     second_monday: 12,

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -29,35 +29,35 @@ class Schedule < ApplicationRecord
 
   class << self
     def insert_schedule_from_batch(batch)
-      dates = create_date_from_cycle(batch.cycle)
+      dates = build_date_from_cycle(batch.cycle)
+      times = dates.map(&:to_time)
       started_at_arr = batch.started_at.split(':')
       finished_at_arr = batch.finished_at.split(':')
 
-      dates.each do |date|
+      times.each do |time|
         Schedule.create!(
           area_sport_id: batch.area_sport_id,
-          started_at: date.change(hour: started_at_arr[0], min: started_at_arr[1]),
-          finished_at: date.change(hour: finished_at_arr[0], min: finished_at_arr[1])
+          started_at: time.change(hour: started_at_arr[0], min: started_at_arr[1]),
+          finished_at: time.change(hour: finished_at_arr[0], min: finished_at_arr[1])
         )
       end
     end
 
     # 日付を出すだけ
-    def create_date_from_cycle(cycle)
+    # in: batch.cycle, out: [Date, Date, ...]
+    def build_date_from_cycle(cycle)
       res = []
       week, day_of_week = cycle.to_s.split('_').map(&:to_sym)
 
-      # :everyのときの処理 # FIX: :everyは施設の営業時間による
-      if (week == :every) && day_of_week.nil?
-        ((Time.zone.now.next_month.beginning_of_month)..(Time.zone.now.next_month.end_of_month)).each do |i|
-          # みたいなことしたい
-          res << i.date
-        end
-        return
-      end
+      return [] if (week == :unknown) && day_of_week.nil?
+
+      # cycle = :every のときは来月の日付を全て返す
+      # FIXME: :everyは施設の営業時間による。現在は、毎月の日数を全て返している。
+      return Date.current.next_month.all_month.to_a if (week == :every) && day_of_week.nil?
 
       # 来月の最初の :day_of_week 曜日
-      first_day_of_week = Time.zone.now.next_month.beginning_of_month.next_occurring(:day_of_week)
+      # FIXME: 1日が月曜日の時に next_occurring(:monday)とすると、8日を返してしまう
+      first_day_of_week = Date.current.next_month.beginning_of_month.next_occurring(day_of_week)
       current_month = first_day_of_week.month
 
       case week
@@ -80,6 +80,8 @@ class Schedule < ApplicationRecord
         fifth_day_of_week = first_day_of_week.since(4.weeks)
         res << fifth_day_of_week if fifth_day_of_week.month == current_month
       end
+
+      res
     end
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -42,15 +42,14 @@ class Schedule < ApplicationRecord
       end
     end
 
-
     # 日付を出すだけ
     def create_date_from_cycle(cycle)
       res = []
       week, day_of_week = cycle.to_s.split('_').map(&:to_sym)
 
       # :everyのときの処理 # FIX: :everyは施設の営業時間による
-      if week == :every && day_of_week.nil?
-        ((Time.now.next_month.beginning_of_month)..(Time.now.next_month.end_of_month)).each do |i|
+      if (week == :every) && day_of_week.nil?
+        ((Time.zone.now.next_month.beginning_of_month)..(Time.zone.now.next_month.end_of_month)).each do |i|
           # みたいなことしたい
           res << i.date
         end
@@ -58,7 +57,7 @@ class Schedule < ApplicationRecord
       end
 
       # 来月の最初の :day_of_week 曜日
-      first_day_of_week = Time.now.next_month.beginning_of_month.next_occurring(:day_of_week)
+      first_day_of_week = Time.zone.now.next_month.beginning_of_month.next_occurring(:day_of_week)
       current_month = first_day_of_week.month
 
       case week
@@ -66,19 +65,19 @@ class Schedule < ApplicationRecord
         # 5週間作って
         5.times do |i|
           # 来月の日付だったらpop
-          res << first_day_of_week.since i.week
+          res << first_day_of_week.since(i.week)
           res.pop if res[-1].month != current_month
         end
       when :first
-        res << first_day_of_week.since 0.week
+        res << first_day_of_week.since(0.weeks)
       when :second
-        res << first_day_of_week.since 1.week
+        res << first_day_of_week.since(1.week)
       when :third
-        res << first_day_of_week.since 2.week
+        res << first_day_of_week.since(2.weeks)
       when :fourth
-        res << first_day_of_week.since 3.week
+        res << first_day_of_week.since(3.weeks)
       when :fifth
-        fifth_day_of_week = first_day_of_week.since 4.week
+        fifth_day_of_week = first_day_of_week.since(4.weeks)
         res << fifth_day_of_week if fifth_day_of_week.month == current_month
       end
     end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,24 +1,3 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
-
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
-
-# Learn more: http://github.com/javan/whenever
-
 require File.expand_path("#{File.dirname(__FILE__)}/environment")
 rails_env = ENV['RAILS_ENV'] || :development
 set :environment, rails_env

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,3 +18,12 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
+
+require File.expand_path("#{File.dirname(__FILE__)}/environment")
+rails_env = ENV['RAILS_ENV'] || :development
+set :environment, rails_env
+set :output, Rails.root.join('log/cron.log')
+
+every 1.month do
+  rake "pluspo:create_next_month_schedules"
+end

--- a/db/fixtures/02_schedule.rb
+++ b/db/fixtures/02_schedule.rb
@@ -1,8 +1,3 @@
-# TODO: 一旦cycleを考慮せずに作ってあるので、cycle考慮して作り直す
 Batch.all.each do |batch|
-  Schedule.create!(
-    area_sport_id: batch.area_sport_id,
-    started_at: Time.zone.parse(batch.started_at),
-    finished_at: Time.zone.parse(batch.finished_at)
-  )
+  Schedule.insert_schedule_from_batch(batch)
 end

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -1,7 +1,3 @@
-# 来月1ヶ月分のScheduleを作成する
-# 引数 : Batch.cycle
-# 戻り値 : 配列で対応する日付を返す
-#        [Time, Time, ..., Time]
 namespace :pluspo do
   desc '月末に翌月のスポーツスケジュールを登録する'
   task create_next_month_schedules: :environment do

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -5,6 +5,8 @@
 namespace :pluspo do
   desc '月末に翌月のスポーツスケジュールを登録する'
   task create_next_month_schedules: :environment do
-    Schedule.insert_schedule_from_batches(Batch.all)
+    Batch.all.each do |batch|
+      Schedule.insert_schedule_from_batch(batch)
+    end
   end
 end

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -1,0 +1,10 @@
+# 来月1ヶ月分のScheduleを作成する
+# 引数 : Batch.cycle
+# 戻り値 : 配列で対応する日付を返す
+#        [Time, Time, ..., Time]
+namespace :pluspo do
+  desc '月末に翌月のスポーツスケジュールを登録する'
+  task create_next_month_schedules: :environment do
+    Schedule.insert_schedule_from_batches(Batch.all)
+  end
+end


### PR DESCRIPTION
## 概要

close #72 
実装できました！
**bundle, db:migrate:reset, db:seed_fuしてください。**

今まではcycleを無視してBatchからScheduleを作成していたものを、cycle考慮する機能を追加。

さらにrakeタスク作ってwheneverで自動化できるようにした。

本番環境での定期実行は多分サービスによる？ため、あとで確認する。（Herokuから乗り換え予定なので）

- gem`whenever`のインストール
- wheneverの設定：`schedule.rb`
- rakeタスクの作成：`schedule.rake`
- 自動でスケジュール作成してくれる機能
- db:seed_fu でも来月のスケジュールが作成できるようにした
- 一覧画面でのソートが消えていたため、復活させた

## 確認方法
- wheneverを入れる
  ```
  bundle install
  ```

- データを入れ直す
  ```
  rails db:migrate:reset
  rails db:seed_fu
  ```

- とりあえずrakeタスクの確認をする（やらなくてOK）
  ```
  # Scheduleが増えればOK
  bundle exec rake "pluspo:create_next_month_schedules" 
  ```

- wheneverでrakeタスクを定期実行する（やらなくてOK）
  ```
  # wheneverの設定更新
  bundle exec whenever --update-crontab
  
  # 設定内容にエラーがないか確認
  bundle exec whenever
  
  # 設定されているcronを見る
  crontab -l
  
  # crontabの設定削除（定期実行を辞めたいとき）
  bundle exec whenever --clear-crontab
  ```

## 影響範囲
schedule.rb
Gemfile
