### PR TITLE
Fix: スケジュールの日時が過去のものは表示しない仕様に変更

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -15,6 +15,6 @@ class PlacesController < ApplicationController
 
   def set_schedules
     @q = Schedule.ransack(params[:q])
-    @schedules = @q.result.page(params[:page]).includes(area_sport: [:sport, { area: :place }]).order(started_at: :asc, finished_at: :asc).order("sport.name")
+    @schedules = @q.result.page(params[:page]).includes(area_sport: [:sport, { area: :place }]).order(started_at: :asc, finished_at: :asc).order("sport.name").after_today
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -27,6 +27,8 @@ class Schedule < ApplicationRecord
     validates :finished_at
   end
 
+  scope :after_today, -> { where("started_at >= ?", Time.current) }
+
   class << self
     def insert_schedule_from_batch(batch)
       dates = build_date_from_cycle(batch.cycle)


### PR DESCRIPTION
## 概要

close #69 

- 以前は作成したスケジュールが全て表示されるようになっていたが、今回は過去のスケジュールを表示しない仕様に変更した

## 確認方法
- `rails c`にて`Schedule.where("started_at >= ?", Time.current)`を打ち込み配列が空なのを確認する
## 影響範囲
- `places_controller.rb`
- `schedule.rb`

## チェックリスト

- [ ] rubocopをパスした
- [ ] rspecをパスした

## コメント
- 今回のPRをマージすると今までのスケジュールのデータが10月11日のものだけなので1つも表示されなくなるので不安ですね
