### PR TITLE
施設詳細のTurbo化

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -22,6 +22,9 @@
 class Schedule < ApplicationRecord
   belongs_to :area_sport
 
+  delegate :area, :sport, to: :area_sport
+  delegate :place, to: :area
+
   with_options presence: true do
     validates :started_at
     validates :finished_at

--- a/app/views/places/_place.html.slim
+++ b/app/views/places/_place.html.slim
@@ -1,4 +1,4 @@
-= turbo_frame_tag place do
+= turbo_frame_tag :place do
   .col-12.mb-2
     = image_tag  "/places/#{place.id}.jpg", { class: 'img-thumbnail', width: '100%' }
   .col-12

--- a/app/views/places/index.html.slim
+++ b/app/views/places/index.html.slim
@@ -1,4 +1,3 @@
-/= turbo_frame_tag @place do
 .row
   .col-6
     = turbo_frame_tag 'place_table' do

--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -1,7 +1,7 @@
 tr
   th = schedule.decorate.date_and_day_of_week
   td = schedule.decorate.full_time
-  td = schedule.area_sport.sport.name
-  td = schedule.area_sport.area.place.city
-  td = link_to places_path(id: schedule.area_sport.area.place.id), class: 'link-dark', data: { turbo_frame: :place } do
-    = schedule.area_sport.area.place.name
+  td = schedule.sport.name
+  td = schedule.place.city
+  td = link_to places_path(id: schedule.place.id), class: 'link-dark', data: { turbo_frame: :place } do
+    = schedule.place.name

--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -3,5 +3,5 @@ tr
   td = schedule.decorate.full_time
   td = schedule.area_sport.sport.name
   td = schedule.area_sport.area.place.city
-  td = link_to places_path(id: schedule.area_sport.area.place.id), class: 'link-dark', data: { turbo: false } do
+  td = link_to places_path(id: schedule.area_sport.area.place.id), class: 'link-dark', data: { turbo_frame: :place } do
     = schedule.area_sport.area.place.name


### PR DESCRIPTION
## 概要

close #102 

- 施設詳細リンクをクリックした際、施設詳細が遷移無しで表示される機能を追加（Turbo使用） [参考](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/turbo-frames)
- delegateを使用して一部リファクタリング

## スクショ

[![Image from Gyazo](https://i.gyazo.com/39ff48ae45199780ab662f708536d165.gif)](https://gyazo.com/39ff48ae45199780ab662f708536d165)

## 確認方法

1. トップページにアクセス
2. 施設詳細リンクをクリック
3. 施設詳細画面が切り替わることを確認
4. URLが変化しないことを確認

## 影響範囲

- 施設詳細画面
