### PR TITLE
Add: モデル名を日本語翻訳

### DIFF
--- a/app/views/places/_place_table.html.slim
+++ b/app/views/places/_place_table.html.slim
@@ -3,11 +3,10 @@
     thead
       tr.text-center
         .mt-4
-          / TODO: モデル名を日本語翻訳して表示する
-          th scope="col"  = t('schedule.decorate.date_and_day_of_week')
-          th scope="col"  = t('schedule.decorate.full_time')
+          th scope="col"  = t('general.date')
+          th scope="col"  = t('general.time')
           th scope="col"  = Sport.model_name.human
-          th scope="col"  = Area.model_name.human
+          th scope="col"  = Place.human_attribute_name(:city)
           th.text-start.ps-4 scope="col"  = Place.model_name.human
     tbody
       = render @schedules

--- a/app/views/places/_place_table.html.slim
+++ b/app/views/places/_place_table.html.slim
@@ -6,8 +6,8 @@
           th scope="col"  = t('general.date')
           th scope="col"  = t('general.time')
           th scope="col"  = Sport.model_name.human
-          th scope="col"  = Place.human_attribute_name(:city)
-          th.text-start.ps-4 scope="col"  = Place.model_name.human
+          th scope="col"  = Place.human_attribute_name(:area)
+          th.text-start.ps-4 scope="col"  = Place.human_attribute_name(:name)
     tbody
       = render @schedules
   .d-flex.justify-content-center.mt-3

--- a/app/views/places/_place_table.html.slim
+++ b/app/views/places/_place_table.html.slim
@@ -4,11 +4,11 @@
       tr.text-center
         .mt-4
           / TODO: モデル名を日本語翻訳して表示する
-          th scope="col"  日付
-          th scope="col"  時刻
-          th scope="col"  スポーツ
-          th scope="col"  エリア
-          th.text-start.ps-4 scope="col"  場所
+          th scope="col"  = t('schedule.decorate.date_and_day_of_week')
+          th scope="col"  = t('schedule.decorate.full_time')
+          th scope="col"  = Sport.model_name.human
+          th scope="col"  = Area.model_name.human
+          th.text-start.ps-4 scope="col"  = Place.model_name.human
     tbody
       = render @schedules
   .d-flex.justify-content-center.mt-3

--- a/app/views/places/_place_table.html.slim
+++ b/app/views/places/_place_table.html.slim
@@ -6,7 +6,7 @@
           th scope="col"  = t('general.date')
           th scope="col"  = t('general.time')
           th scope="col"  = Sport.model_name.human
-          th scope="col"  = Place.human_attribute_name(:area)
+          th scope="col"  = Place.human_attribute_name(:city)
           th.text-start.ps-4 scope="col"  = Place.human_attribute_name(:name)
     tbody
       = render @schedules

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  activerecord:
+    models:
+      sport: 'スポーツ'
+      area: 'エリア'
+      place: '場所'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,7 +2,7 @@ ja:
   activerecord:
     models:
       sport: スポーツ
-      place: 場所
     attributes:
       place:
-        city: エリア
+        area: 地区 
+        name: 施設名

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,5 +4,5 @@ ja:
       sport: スポーツ
     attributes:
       place:
-        area: 地区 
+        city: 地区 
         name: 施設名

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,6 +1,8 @@
 ja:
   activerecord:
     models:
-      sport: 'スポーツ'
-      area: 'エリア'
-      place: '場所'
+      sport: スポーツ
+      place: 場所
+    attributes:
+      place:
+        city: エリア

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,6 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
-  schedule:
-    decorate:
-      full_time: '時刻'
-      date_and_day_of_week: '日付'
+  general:
+    time: '時刻'
+    date: '日付'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,5 +3,5 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
   general:
-    time: '時刻'
-    date: '日付'
+    time: 時刻
+    date: 日付

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,7 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
+  schedule:
+    decorate:
+      full_time: '時刻'
+      date_and_day_of_week: '日付'


### PR DESCRIPTION
## 概要
- 日付・時刻・スポーツ・エリア・場所の部分を日本語訳して表示させました
[![Image from Gyazo](https://i.gyazo.com/2c2868789b4c227d500f18b611093a11.png)](https://gyazo.com/2c2868789b4c227d500f18b611093a11)
問題なく表示できています
## issue
close #120 
## 確認方法
- TOPページで日本語で表示されているのを確認してください
- Gemfileもそれ以外も特にいじっていないので`git pull`して頂けたら確認できると思います

## 影響範囲
- TOPページ
## チェックリスト

- [x] rubocopをパスした
- [x] rspecをパスした

## コメント
1つ気になっていることがあります。
```
th scope="col"  = t('schedule.decorate.date_and_day_of_week')
th scope="col"  = t('schedule.decorate.full_time')
th scope="col"  = Sport.model_name.human
th scope="col"  = Area.model_name.human
th.text-start.ps-4 scope="col"  = Place.model_name.human
```
このように日本語訳しているのですが`日付`と`時刻`の部分だけlocales/ja.ymlで翻訳しています。理由はdecoratorでそれぞれ`full_time`と`date_and_day_of_week`を定義しているためモデル名で翻訳するのが適切でないと思ったからです。
これで大丈夫ですかね？
ちなみにlocales/ja.ymlは以下のような階層で翻訳しています
```
ja:
  time:
    formats:
      default: "%Y/%m/%d %H:%M:%S"
  schedule:
    decorate:
      full_time: '時刻'
      date_and_day_of_week: '日付'

```