### PR TITLE
1日のスケジュールが入らないバグの修正

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -61,8 +61,8 @@ class Schedule < ApplicationRecord
       return Date.current.next_month.all_month.to_a if (week == :every) && day_of_week.nil?
 
       # 来月の最初の :day_of_week 曜日
-      # FIXME: 1日が月曜日の時に next_occurring(:monday)とすると、8日を返してしまう
-      first_day_of_week = Date.current.next_month.beginning_of_month.next_occurring(day_of_week)
+      first_day_of_week_next_month = Date.current.next_month.beginning_of_month
+      first_day_of_week = first_day_of_week_next_month.strftime('%A').downcase.to_sym == day_of_week ? first_day_of_week_next_month : first_day_of_week_next_month.next_occurring(day_of_week)
       current_month = first_day_of_week.month
 
       case week

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -35,7 +35,7 @@ class Schedule < ApplicationRecord
   class << self
     def insert_schedule_from_batch(batch)
       dates = build_date_from_cycle(batch.cycle)
-      times = dates.map(&:to_time)
+      times = dates&.map(&:to_time)
       started_at_arr = batch.started_at.split(':')
       finished_at_arr = batch.finished_at.split(':')
 


### PR DESCRIPTION
<!-- レビュアーの負担にならないプルリクエストを心がけましょう -->
<!-- 気になる点やコードの補足についてはセルフレビューしましょう！ -->
<!-- 作業中だけど一旦レビュー欲しい人はタイトル頭に[WIP]を追加してください -->

## 概要

close #105 
1日のスケジュールが入らないバグを修正しました。
無理やりな条件分岐だけど、これでいいのだろうか。。。
もっと良い書き方あったら教えてください！

## スクショ

|  変更前  |  変更後  |
| :----: | :----: |
|  2/1が表示されていない<br><br><a href="https://gyazo.com/02b4d2a5a094b18b14eae020a08eedfa"><img src="https://i.gyazo.com/02b4d2a5a094b18b14eae020a08eedfa.png" alt="Image from Gyazo" width="400"/></a>  |  2/1が表示されている<br><br><a href="https://gyazo.com/5b9a0541ee756f356e14f336df366c86"><img src="https://i.gyazo.com/5b9a0541ee756f356e14f336df366c86.png" alt="Image from Gyazo" width="400"/></a>  |

## 確認方法

コメントに書きます。

## 影響範囲

- `models/schedule.rb`

## チェックリスト

- [x] rubocopをパスした
- [ ] rspecをパスした
