### PR TITLE
Fix: views/schedules/_schedule.html.slim .truncate()

### DIFF
--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -1,7 +1,7 @@
 tr
   th = schedule.decorate.date_and_day_of_week
   td = schedule.decorate.full_time
-  td = schedule.sport.name
+  td = schedule.sport.name.truncate(8, omission: '…')
   td = schedule.place.city
   td = link_to places_path(id: schedule.place.id), class: 'link-dark', data: { turbo_frame: :place } do
-    = schedule.place.name
+    = schedule.place.name.truncate(15, omission: '…')


### PR DESCRIPTION
<!-- レビュアーの負担にならないプルリクエストを心がけましょう -->
<!-- 気になる点やコードの補足についてはセルフレビューしましょう！ -->
<!-- 作業中だけど一旦レビュー欲しい人はタイトル頭に[WIP]を追加してください -->

## 概要
テーブルのスポーツ名、施設名の表示可能文字数の調整
  - スポーツ名 8文字
  - 施設名 15文字
  - 上記より多い文字数の場合```…```表示
close #134

変更前
[![Image from Gyazo](https://i.gyazo.com/3680785ff4640386771d44636f5f8cf7.png)](https://gyazo.com/3680785ff4640386771d44636f5f8cf7)

変更後
[![Image from Gyazo](https://i.gyazo.com/20ec95cff786d5116ae70d70d7fc9575.png)](https://gyazo.com/20ec95cff786d5116ae70d70d7fc9575)

[![Image from Gyazo](https://i.gyazo.com/f6abe2184f76868f8b4c8f50141ff8bf.png)](https://gyazo.com/f6abe2184f76868f8b4c8f50141ff8bf)


## 確認方法

1. TOPページにアクセス
2. スポーツ名、施設名で文字数が設定より多い場合```…```が表示されることを確認
3. その他ページでも同様の結果になることを確認


