### PR TITLE
Modify: 日付検索できるように修正

### DIFF
--- a/app/views/shared/_search_schedule_form.html.slim
+++ b/app/views/shared/_search_schedule_form.html.slim
@@ -4,7 +4,10 @@
     /  = sports.each do |sport|
     /    option value="#{sport.name}"
 
-  = f.date_field :started_at_eq, class: "form-control me-2", id: "calendar", placeholder: "開始日時", readonly: "readonly"
+  = f.date_field :started_at_gteq, class: "form-control me-2", id: "calendar-1", placeholder: "開始日時"
+  span
+    | ~
+  = f.date_field :finished_at_lteq_end_of_day, class: "form-control me-2", id: "calendar-2", placeholder: "終了日時"
 
   // TODO: 後でマスタ化
   - cities = ['中央区', '千代田区', '文京区', '港区', '新宿区', '品川区', '目黒区', '大田区', '世田谷区', '渋谷区', '中野区', '杉並区', '練馬区', '板橋区', '豊島区', '北区', '台東区', '墨田区', '江東区', '荒川区', '足立区', '葛飾区', '江戸川区']

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,5 @@
+Ransack.configure do |config|
+  config.add_predicate 'lteq_end_of_day',
+                  arel_predicate: 'lteq',
+                  formatter: proc { |v| v.end_of_day }
+end


### PR DESCRIPTION
## 概要

close #135
日付検索できるように修正しました。
2回目以降も検索可能になってます！！

https://school.runteq.jp/v2/curriculums/rails_basic/chapters/27
カリキュラムとほぼ同じです

## 確認方法

1. localでトップページにアクセス
2. カレンダーが2個表示されることを確認
[![Image from Gyazo](https://i.gyazo.com/77509d8e27d0232f00a3f8c37ff8a5ac.jpg)](https://gyazo.com/77509d8e27d0232f00a3f8c37ff8a5ac)
4. 日付を２つ指定してserachボタンをクリック
[![Image from Gyazo](https://i.gyazo.com/e37fc6cd598c5107a693e5d8d9966cbc.png)](https://gyazo.com/e37fc6cd598c5107a693e5d8d9966cbc)
6. カレンダーで日時選択が可能なことを確認

## 影響範囲

スポーツの開始日と終了日で検索できるようにしました。
2/1と2/3を指定すると、開始時間2月1日0時〜から終了時間2月3日23時59分までの検索結果が表示される仕組みになってます。
カレンダーの色が消えました（）
時間選べなくなりました（）
カレンダーが2個になりました（）
とりあえずバグを直すことを第一優先にしたので、この実装でよければレイアウトも直します。


## チェックリスト

- [x] rubocopをパスした
- [ ] rspecをパスした
