### PR TITLE
施設情報のURL、電話番号などをリンク対応にする 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'ransack'
 gem 'rails-i18n'
 gem 'kaminari'
 gem 'whenever', require: false
+gem 'rails_autolink'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
     rails-i18n (7.0.5)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_autolink (1.1.7)
+      rails (> 3.1)
     railties (7.0.3.1)
       actionpack (= 7.0.3.1)
       activesupport (= 7.0.3.1)
@@ -382,6 +384,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)
   rails-i18n
+  rails_autolink
   ransack
   rspec-rails (= 6.0.0.rc1)
   rubocop

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  PHONE_NUMBER_REGEXP = /\+?[ 0-9()-]{9,}[0-9)]/
+
+  def auto_phone_to(html)
+    html.gsub(PHONE_NUMBER_REGEXP) do |match|
+      phone_to(match)
+    end.html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,8 @@
 module ApplicationHelper
   PHONE_NUMBER_REGEXP = /\+?[ 0-9()-]{9,}[0-9)]/
 
-  def auto_phone_to(html)
+  def all_auto_link(html, option)
+    html = auto_link(html, option)
     html.gsub(PHONE_NUMBER_REGEXP) do |match|
       phone_to(match)
     end.html_safe

--- a/app/views/places/_place.html.slim
+++ b/app/views/places/_place.html.slim
@@ -27,6 +27,5 @@
         h4#scrollspyHeading4 開館時間
         p = place.opening_hours
         h4#scrollspyHeading5 その他
-        - place.message.split("\n").each do |message|
-          p = message
-        / TODO: areaごとのnoteもこの下に表示したい
+        = auto_phone_to(auto_link(simple_format(place.message.gsub(/\n/, "\n\n"), wrapper_tag: 'p'), html: {target: '_blank'}))
+        // TODO: areaごとのnoteもこの下に表示したい

--- a/app/views/places/_place.html.slim
+++ b/app/views/places/_place.html.slim
@@ -27,5 +27,5 @@
         h4#scrollspyHeading4 開館時間
         p = place.opening_hours
         h4#scrollspyHeading5 その他
-        = auto_phone_to(auto_link(simple_format(place.message.gsub(/\n/, "\n\n"), wrapper_tag: 'p'), html: {target: '_blank'}))
+        = all_auto_link(simple_format(place.message.gsub(/\n/, "\n\n"), wrapper_tag: 'p'), html: {target: '_blank'})
         // TODO: areaごとのnoteもこの下に表示したい


### PR DESCRIPTION
<!-- レビュアーの負担にならないプルリクエストを心がけましょう -->
<!-- 気になる点やコードの補足についてはセルフレビューしましょう！ -->
<!-- 作業中だけど一旦レビュー欲しい人はタイトル頭に[WIP]を追加してください -->

## 概要

* 施設情報のメッセージ内にあるリンクや電話番号をHTMLのリンクに置き換えた
* simple_formatを使って、改行メッセージの表示をシンプルに


close #136 


## 確認方法

1. トップページにアクセス
2. 一覧の施設名をクリック
3. 施設情報のリンクや電話番号がクリッカブルなリンクに変更されている
