### PR TITLE
Fix: コンフリクト解消の際に削除していまった検索ボタン復活

### DIFF
--- a/app/views/shared/_search_schedule_form.html.slim
+++ b/app/views/shared/_search_schedule_form.html.slim
@@ -14,6 +14,8 @@ button.btn.btn-outline-success data-bs-toggle="modal" data-bs-target="#exampleMo
           span
             h2.text-center.mb-1. ≀
           = f.date_field :finished_at_lteq_end_of_day, class: "form-control me-2 mb-4", id: "calendar-2", placeholder: "終了日時"
-          = f.select :area_sport_area_place_city_eq, options_for_select(Place.all.pluck(:city).uniq), {include_blank: 'エリア'}, class: 'form-select form-control me-2'
-          / TODO: 検索機能をajaxで実装したらSearchボタンは消す
-          = button_tag 'Search', class: 'btn btn-primary'
+          = f.select :area_sport_area_place_city_eq, options_for_select(Place.all.pluck(:city).uniq), {include_blank: 'エリア'}, class: 'form-select form-control me-2 mb-4'
+          .d-grid.gap-2
+            = button_tag t('defaults.search'), class: 'btn btn-outline-success'
+      .modal-footer
+        button.btn-close type="button" data-bs-dismiss="modal" aria-label="Close"


### PR DESCRIPTION
## 概要
コンフリクト解消の際に削除していまった検索ボタン復活

## 影響範囲
- ヘッダー


## チェックリスト

- [ ] rubocopをパスした
- [ ] rspecをパスした
