### PR TITLE
WIP: collapseで施設詳細表示途中

### DIFF
--- a/app/views/places/_place_table.html.slim
+++ b/app/views/places/_place_table.html.slim
@@ -1,7 +1,7 @@
 .place_table
   table.table.table-sm.table-hover
     thead
-      tr.text-center
+      tr.text-start
         .mt-4
           th scope="col"  = t('general.date')
           th scope="col"  = t('general.time')
@@ -10,5 +10,8 @@
           th.text-start.ps-4 scope="col"  = Place.human_attribute_name(:name)
     tbody
       = render @schedules
+      #collapseExample.collapse
+        .card.card-body
+          = render @place
   .d-flex.justify-content-center.mt-3
     = paginate @schedules

--- a/app/views/places/index.html.slim
+++ b/app/views/places/index.html.slim
@@ -1,8 +1,2 @@
-.row
-  .col-6
-    = turbo_frame_tag 'place_table' do
-      = render 'place_table'
-  .col-6
-    .place-show style="background-color: aliceblue;"
-      .row
-        = render @place
+= turbo_frame_tag 'place_table' do
+  = render 'place_table'

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,0 +1,11 @@
+<tr>
+  <th><%= schedule.decorate.date_and_day_of_week %></th>
+  <td><%= schedule.decorate.full_time %></td>
+  <td><%= schedule.sport.name.truncate(8, omission: '…') %>
+  <td><%= schedule.place.city %></td>
+  <td>
+    <%= link_to places_path(id: schedule.place.id), class: 'link-dark', 'data-bs-toggle': :'collapse', 'data-bs-target': :'#collapseExample', 'aria-expanded': :'false', 'aria-controls': :'collapseExample', data: { turbo_frame: :place } do %>
+      <%= schedule.place.name.truncate(15, omission: '…') %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -1,7 +1,0 @@
-tr
-  th = schedule.decorate.date_and_day_of_week
-  td = schedule.decorate.full_time
-  td = schedule.sport.name.truncate(8, omission: '…')
-  td = schedule.place.city
-  td = link_to places_path(id: schedule.place.id), class: 'link-dark', data: { turbo_frame: :place } do
-    = schedule.place.name.truncate(15, omission: '…')


### PR DESCRIPTION
## 概要
- collapseで施設詳細を表示する途中です
- 予定ではカレンダーの下にcollapseで詳細が表示される予定なのですが上に表示されます
- 単純なミスだと思うのですが、、
[![Image from Gyazo](https://i.gyazo.com/ce7606837b16778f120a11ef70ed1440.gif)](https://gyazo.com/ce7606837b16778f120a11ef70ed1440)
## 確認方法

1. 〇〇ページにアクセス
2. 〇〇が表示されることを確認
3. 〇〇ボタンをクリック
4. 〇〇が表示されなくなることを確認

## 影響範囲

## チェックリスト

- [ ] rubocopをパスした
- [ ] rspecをパスした
