### PR TITLE
Add: footer作った

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -49,3 +49,15 @@ button.btn-primary:hover {
   background-color: #237291 !important;
   border: solid 1px #237291 !important;
 }
+
+footer {
+  background-color: #eef2e2;
+}
+
+.footer_link {
+  color: #237291
+}
+
+.footer_link:hover{
+  opacity: 0.5 ;
+}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -22,3 +22,4 @@ html
     = render 'shared/header'
     .container
       = yield
+    = render 'shared/footer'

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -8,12 +8,18 @@
           <div class="p-2 footer_link">
             <%= link_to '利用規約', terms_path, class: "footer_link ms-1" %>
           </div>
+        <%
+=begin
+        %>
           <div class="p-2 footer_link">
             <%= link_to 'プライバシーポリシー', '#', class: "footer_link ms-1" %>
           </div>
           <div class="p-2 footer_link">
-            <%= link_to 'お問合せ', '#', class: "footer_link ms-1" %>
+            <% link_to 'お問合せ', '#', class: "footer_link ms-1" %>
           </div>
+        <%
+=end
+        %>
           <div class="p-2 footer_explain">
             <p class="footer_link">Copyright © Pluspo 2023.<br>All rights reserved.</p>
           </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,23 @@
+<footer class="text-center mt-5">
+  <div class="container">
+    <div class="row">
+      <div class="col">
+          <div class="p-2 mt-2 center-block">
+            <%= image_tag 'logo_no_subtitle.png', { width: '150px' } %>
+          </div>
+          <div class="p-2 footer_link">
+            <%= link_to '利用規約', terms_path, class: "footer_link ms-1" %>
+          </div>
+          <div class="p-2 footer_link">
+            <%= link_to 'プライバシーポリシー', '#', class: "footer_link ms-1" %>
+          </div>
+          <div class="p-2 footer_link">
+            <%= link_to 'お問合せ', '#', class: "footer_link ms-1" %>
+          </div>
+          <div class="p-2 footer_explain">
+            <p class="footer_link">Copyright © Pluspo 2023.<br>All rights reserved.</p>
+          </div>
+      </div>
+    </div>
+  </div>
+</footer>


### PR DESCRIPTION
## 概要

close #162
footer作りました。
一応、利用規約含めて3つボタン作りました。pluspoのロゴはリンクになってません。

＜スマホから見た画像＞
[![Image from Gyazo](https://i.gyazo.com/1c99fa6683ef8813c73e473726a7d70f.png)](https://gyazo.com/1c99fa6683ef8813c73e473726a7d70f)
＜PCから見た画像＞
[![Image from Gyazo](https://i.gyazo.com/d3920528043a088765db233152242288.png)](https://gyazo.com/d3920528043a088765db233152242288)



## 確認方法

1. トップページにアクセス
2. フッターが表示されることを確認
3. 利用規約を押すと、/termsに移動することを確認してください


## 影響範囲
特になし


## チェックリスト

- [ ] rubocopをパスした
- [ ] rspecをパスした
