### PR TITLE
Fix: スケジュールをレスポンシブ対応

### DIFF
--- a/app/decorators/schedule_decorator.rb
+++ b/app/decorators/schedule_decorator.rb
@@ -2,7 +2,7 @@ class ScheduleDecorator < ApplicationDecorator
   delegate_all
 
   def full_time
-    "#{started_at.strftime('%H:%M')}~#{finished_at.strftime('%H:%M')}"
+    "#{started_at.strftime('%H:%M')}\n~#{finished_at.strftime('%H:%M')}"
   end
 
   def date_and_day_of_week

--- a/app/views/places/_place_table.html.slim
+++ b/app/views/places/_place_table.html.slim
@@ -7,7 +7,7 @@
           th scope="col"  = t('general.time')
           th scope="col"  = Sport.model_name.human
           th scope="col"  = Place.human_attribute_name(:city)
-          th.text-start.ps-4 scope="col"  = Place.human_attribute_name(:name)
+          th.ps-4 scope="col"  = Place.human_attribute_name(:name)
     tbody
       = render @schedules
   .d-flex.justify-content-center.mt-3


### PR DESCRIPTION
## 概要
close #156 
## 見た目
- スマホ版
[![Image from Gyazo](https://i.gyazo.com/3da212c86bf87961e929f43200a32089.png)](https://gyazo.com/3da212c86bf87961e929f43200a32089)
- PC版
[![Image from Gyazo](https://i.gyazo.com/00d8efa06a66346b6e50d2c4430d71e8.png)](https://gyazo.com/00d8efa06a66346b6e50d2c4430d71e8)

## 確認方法

1. TOPページにアクセス
2. スマホ版でtable名とスケジュールがGyazo通りに表示されることを確認

## 影響範囲
- app/decorators/schedule_decorator.rb

## チェックリスト

- [x] rubocopをパスした
- [ ] rspecをパスした
