### PR TITLE
本番環境で施設詳細が切り替わらないバグの修正

### DIFF
--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -3,5 +3,5 @@ tr
   td = schedule.decorate.full_time
   td = schedule.sport.name.truncate(8, omission: '…')
   td = schedule.place.city
-  td = link_to places_path(id: schedule.place.id), onclick: "ScrollWindow('place')", class: 'link-dark', data: { turbo_frame: :place } do
+  td = link_to places_path + "/?id=#{schedule.place.id}", onclick: "ScrollWindow('place')", class: 'link-dark', data: { turbo_frame: :place } do
     = schedule.place.name.truncate(15, omission: '…')

--- a/db/fixtures/02_schedule.rb
+++ b/db/fixtures/02_schedule.rb
@@ -3,4 +3,4 @@ Batch.all.each do |batch|
 end
 
 # レコード数を確認する
-!ApplicationRecord.descendants.map(&:name).map(&:safe_constantize).map { |m| [m, m.count] }.each { |a| printf "%<model>10s%<count>6d\n", *a }
+# !ApplicationRecord.descendants.map(&:name).map(&:safe_constantize).map { |m| [m, m.count] }.each { |a| printf "%<model>10s%<count>6d\n", *a }


### PR DESCRIPTION
<!-- レビュアーの負担にならないプルリクエストを心がけましょう -->
<!-- 気になる点やコードの補足についてはセルフレビューしましょう！ -->
<!-- 作業中だけど一旦レビュー欲しい人はタイトル頭に[WIP]を追加してください -->

## 概要

close #169 

本番環境( https://pluspo.fly.dev/ )で施設詳細が切り替わらないバグを修正しました。
原因がわからないですが、本番環境だけURLのクエリパラメーターが失われてしまっていました。

施設詳細リンクのURLを変更しました`places?id=4` => `places/?id=4`

参考：https://sbu8.hatenablog.com/entry/2020/08/29/180559

## 確認方法

本番環境で施設詳細が切り替わることを確認する。

## スクショ

[![Image from Gyazo](https://i.gyazo.com/e60592560f5dac648e194532e70dc45c.gif)](https://gyazo.com/e60592560f5dac648e194532e70dc45c)