### PR TITLE
当月のスケジュールも登録されるように変更

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -57,14 +57,15 @@ class Schedule < ApplicationRecord
 
       return [] if (week == :unknown) && day_of_week.nil?
 
+      current_month = Date.current.next_month
+
       # cycle = :every のときは来月の日付を全て返す
       # FIXME: :everyは施設の営業時間による。現在は、毎月の日数を全て返している。
-      return Date.current.next_month.all_month.to_a if (week == :every) && day_of_week.nil?
+      return current_month.all_month.to_a if (week == :every) && day_of_week.nil?
 
       # 来月の最初の :day_of_week 曜日
-      first_day_of_week_next_month = Date.current.next_month.beginning_of_month
+      first_day_of_week_next_month = current_month.beginning_of_month
       first_day_of_week = first_day_of_week_next_month.strftime('%A').downcase.to_sym == day_of_week ? first_day_of_week_next_month : first_day_of_week_next_month.next_occurring(day_of_week)
-      current_month = first_day_of_week.month
 
       case week
       when :every
@@ -72,7 +73,7 @@ class Schedule < ApplicationRecord
         5.times do |i|
           # 来月の日付だったらpop
           res << first_day_of_week.since(i.week)
-          res.pop if res[-1].month != current_month
+          res.pop if res[-1].month != current_month.month
         end
       when :first
         res << first_day_of_week.since(0.weeks)
@@ -84,7 +85,7 @@ class Schedule < ApplicationRecord
         res << first_day_of_week.since(3.weeks)
       when :fifth
         fifth_day_of_week = first_day_of_week.since(4.weeks)
-        res << fifth_day_of_week if fifth_day_of_week.month == current_month
+        res << fifth_day_of_week if fifth_day_of_week.month == current_month.month
       end
 
       res

--- a/db/fixtures/02_schedule.rb
+++ b/db/fixtures/02_schedule.rb
@@ -1,6 +1,7 @@
 Batch.all.each do |batch|
-  Schedule.insert_schedule_from_batch(batch)
+  Schedule.insert_schedule_from_batch(batch, 0)
+  Schedule.insert_schedule_from_batch(batch, 1)
 end
 
 # レコード数を確認する
-# !ApplicationRecord.descendants.map(&:name).map(&:safe_constantize).map { |m| [m, m.count] }.each { |a| printf "%<model>10s%<count>6d\n", *a }
+# !ApplicationRecord.descendants.map(&:name).map(&:safe_constantize).map { |m| [m, m.count] }.each { |a| printf "%<model>10s%<count>6d\n", *a } if ApplicationRecord.descendants.any?

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -2,7 +2,7 @@ namespace :pluspo do
   desc '月末に翌月のスポーツスケジュールを登録する'
   task create_next_month_schedules: :environment do
     Batch.all.each do |batch|
-      Schedule.insert_schedule_from_batch(batch)
+      Schedule.insert_schedule_from_batch(batch, 1)
     end
   end
 end


### PR DESCRIPTION
<!-- レビュアーの負担にならないプルリクエストを心がけましょう -->
<!-- 気になる点やコードの補足についてはセルフレビューしましょう！ -->
<!-- 作業中だけど一旦レビュー欲しい人はタイトル頭に[WIP]を追加してください -->

# 3/11現在、fly.ioへのデプロイが失敗するため、マージしないように！！

## 概要

close #160

- seed_fu打った際に今月と来月のスケジュールが生成されるように変更
- スケジュール作成のメソッドは呼び出し側で何ヶ月先のデータを入れるかを指定できるように変更