### PR TITLE
Fix: N+1問題を解決

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -10,11 +10,11 @@ class PlacesController < ApplicationController
 
   def set_place
     params[:id] ||= 1 # なんか違う気もする
-    @place = Place.find(params[:id]).decorate
+    @place = Place.includes(areas: [area_sports: :sport]).find(params[:id]).decorate
   end
 
   def set_schedules
     @q = Schedule.ransack(params[:q])
-    @schedules = @q.result.page(params[:page]).includes(area_sport: [:sport, { area: :place }]).order(started_at: :asc, finished_at: :asc).order("sport.name").after_today
+    @schedules = @q.result.includes(area_sport: [:sport, area: :place]).order(started_at: :asc, finished_at: :asc).order("sport.name").after_today.page(params[:page])
   end
 end


### PR DESCRIPTION
## 概要

close #182 


## 確認方法

1. 開発環境でTOPページにアクセス
2. ターミナルからログを確認し大量のSQLが発行されていないことを確認

## 影響範囲
- placescontroller


## チェックリスト

- [ ] rubocopをパスした
- [ ] rspecをパスした

## 備考
```
user: haradayoshihiro
GET /
AVOID eager loading detected
  Area => [:area_sports, :place]
  Remove from your query: .includes([:area_sports, :place])
Call stack


user: haradayoshihiro
GET /
AVOID eager loading detected
  AreaSport => [:sport, :area]
  Remove from your query: .includes([:sport, :area])
Call stack
```
どうやら余分にincludesしてしまっているみたいですが、` .includes([:area_sports, :place])`と`.includes([:sport, :area])`の部分をRemoveしてしまうと元に戻ってN+1問題が発生します。
N+1問題は解決しているのですが、、